### PR TITLE
Make Container and PsrStorageBridge services public

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -51,7 +51,9 @@ services:
         arguments:
             - '@Railt\Container\ContainerInterface'
             - '@Railt\Foundation\Application\Configurator'
+        tags: ['controller.service_arguments']
 
     Railt\SymfonyBundle\Storage\PSR6StorageBridge:
+        public: true
         arguments:
             - '@Psr\Cache\CacheItemPoolInterface'


### PR DESCRIPTION
Symfony 4 has private services by default.

When I use `RailtBundle:GraphQL:handle` controller in routing configuration, I get exception:
> Controller "Railt\SymfonyBundle\Controller\GraphQLController" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?

```
# routing.yml
api:
    path: /api
    methods: [ 'POST', 'OPTIONS' ]
    defaults:
        _controller: RailtBundle:GraphQL:handle
```

Cache also can't be injected:
`Can not resolve parameter Railt\Foundation\Services\{closure}([#0 => cache])`